### PR TITLE
Adds check for array before iterating

### DIFF
--- a/src/Plugin/Field/FieldWidget/SocialMetatagPreview.php
+++ b/src/Plugin/Field/FieldWidget/SocialMetatagPreview.php
@@ -65,13 +65,15 @@ class SocialMetatagPreview extends MetatagFirehose {
 
     $tags = metatag_get_tags_from_route($entity);
     $tag_values = [];
-    foreach ($tags['#attached']['html_head'] as $tag) {
-      if (isset($tag[0]['#attributes']['href'])) {
-        $tag_values[$tag[1]] = $tag[0]['#attributes']['href'];
-      }
-      elseif (isset($tag[0]['#attributes']['content'])) {
-        $tag_values[$tag[1]] = $tag[0]['#attributes']['content'];
-      }
+    if (isset($tags['#attached'])) {
+      foreach ($tags['#attached']['html_head'] as $tag) {
+        if (isset($tag[0]['#attributes']['href'])) {
+          $tag_values[$tag[1]] = $tag[0]['#attributes']['href'];
+        }
+        elseif (isset($tag[0]['#attributes']['content'])) {
+          $tag_values[$tag[1]] = $tag[0]['#attributes']['content'];
+        }
+      }    
     }
 
     // Generate the social preview.


### PR DESCRIPTION
This is the error that was happening on new content creation: 
```
Warning: Invalid argument supplied for foreach() in Drupal\social_metatag_preview\Plugin\Field\FieldWidget\SocialMetatagPreview->formElement() (line 68 of /code/web/modules/composer/social_metatag_preview/src/Plugin/Field/FieldWidget/SocialMetatagPreview.php)
```

This patch fixes the error, but wasn't sure how to test if it breaks other expected functionality.